### PR TITLE
Rework FitFile merge

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
     <Nullable>disable</Nullable>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>4.2.6</VersionPrefix>
-    <BuildIncrement>31</BuildIncrement>
+    <VersionPrefix>4.3.0</VersionPrefix>
+    <BuildIncrement>32</BuildIncrement>
     <VersionSuffix></VersionSuffix>
     <Product>FitEdit</Product>
     <Copyright>EnduraByte LLC 2024</Copyright>

--- a/Infrastructure/FitEdit.Adapters.Fit/FieldBase.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/FieldBase.cs
@@ -147,11 +147,13 @@ namespace Dynastream.Fit
 
         case Fit.String:
           // Each string may be of differing length
+          int len = 0; // use int since byte can overflow
           // The fit binary must also include a null terminator
           foreach (byte[] element in values)
           {
-            size += (byte)(element.Length);
+            len += element.Length;
           }
+          size = len > 255 ? (byte)255 : (byte)len;
           break;
 
         default:

--- a/Infrastructure/FitEdit.Adapters.Fit/Profile/Mesgs/ActivityMesg.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/Profile/Mesgs/ActivityMesg.cs
@@ -24,7 +24,7 @@ namespace Dynastream.Fit
     /// <summary>
     /// Implements the Activity profile message.
     /// </summary>
-    public class ActivityMesg : Mesg
+    public class ActivityMesg : Mesg, IInstantOfTime
     {
         #region Fields
         #endregion

--- a/Ui/FitEdit.Ui.iOS/Info.plist
+++ b/Ui/FitEdit.Ui.iOS/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleIdentifier</key>
     <string>com.endurabyte.fitedit</string>
     <key>CFBundleShortVersionString</key>
-    <string>4.2.6</string>
+    <string>4.3.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true />
     <key>MinimumOSVersion</key>
@@ -57,6 +57,6 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>31</string>
+    <string>32</string>
   </dict>
 </plist>

--- a/Ui/FitEdit.Ui/ViewModels/FileViewModel.cs
+++ b/Ui/FitEdit.Ui/ViewModels/FileViewModel.cs
@@ -395,7 +395,7 @@ public class FileViewModel : ViewModelBase, IFileViewModel
     if (uif == null) { return; }
     uif.Progress = 0;
     uif.IsLoaded = false;
-    FileService.MainFile = FileService.Files.FirstOrDefault(f => f.IsLoaded);
+    FileService.MainFile = null;
   }
 
   private async Task LoadFile(UiFile? uif)

--- a/Ui/FitEdit.Ui/ViewModels/RecordViewModel.cs
+++ b/Ui/FitEdit.Ui/ViewModels/RecordViewModel.cs
@@ -15,6 +15,7 @@ using DynamicData.Binding;
 using Dynastream.Fit;
 using ReactiveUI;
 using ReactiveUI.Fody.Helpers;
+using System.Collections.Concurrent;
 
 namespace FitEdit.Ui.ViewModels;
 
@@ -86,7 +87,7 @@ public class RecordViewModel : ViewModelBase, IRecordViewModel
   private readonly IWindowAdapter window_;
   private IDisposable? selectedIndexSub_;
   private IDisposable? selectedCountSub_;
-  private readonly HashSet<IDisposable> messageSubs_ = new();
+  private readonly ConcurrentDictionary<IDisposable, IDisposable> messageSubs_ = new();
   private DataGridWrapper? records_;
   private MessageWrapper? selectedMessage_;
   private readonly MesgFieldValueConverter converter_;
@@ -275,7 +276,7 @@ public class RecordViewModel : ViewModelBase, IRecordViewModel
     selectedCountSub_?.Dispose();
     foreach (var sub in messageSubs_)
     {
-      sub.Dispose();
+      sub.Value.Dispose();
     }
     messageSubs_.Clear();
 
@@ -479,7 +480,7 @@ public class RecordViewModel : ViewModelBase, IRecordViewModel
         IDisposable sub = wrapper
           .WhenPropertyChanged(x => x.Mesg, notifyOnInitialValue: false)
           .Subscribe(_ => HandleMessagePropertyChanged(wrapper));
-        messageSubs_.Add(sub);
+        messageSubs_[sub] = sub;
       }
     });
 


### PR DESCRIPTION
Rework merge feature. Now concatenates all messages as before but removes duplicates e.g. there must be only one ActivityMesg.

Fixes a few bugs related to jankiness of the Data tab when loading/unloading FitFiles.