### PR TITLE
Feature/ensure cumulative distance

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
     <Nullable>disable</Nullable>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>4.3.0</VersionPrefix>
-    <BuildIncrement>32</BuildIncrement>
+    <VersionPrefix>4.4.0</VersionPrefix>
+    <BuildIncrement>33</BuildIncrement>
     <VersionSuffix></VersionSuffix>
     <Product>FitEdit</Product>
     <Copyright>EnduraByte LLC 2024</Copyright>

--- a/Infrastructure/FitEdit.Data/Fit/FitFileExtensions.cs
+++ b/Infrastructure/FitEdit.Data/Fit/FitFileExtensions.cs
@@ -528,7 +528,7 @@ public static class FitFileExtensions
   }
 
   /// <summary>
-  /// The distance of each record be cumulative.
+  /// The distance of each record should be cumulative.
   /// If it is not, assume the discontinuity is due to a sketchy FIT file merge
   /// and repair it by making the distance cumulative.
   /// Return a new list of records; do not modify the given list.

--- a/Ui/FitEdit.Ui.Android/Resources/drawable/splash_screen.xml
+++ b/Ui/FitEdit.Ui.Android/Resources/drawable/splash_screen.xml
@@ -5,9 +5,9 @@
     <color android:color="@color/splash_background"/>
   </item>
 
-  <item android:drawable="@drawable/icon"
+  <!--<item android:drawable="@drawable/icon"
         android:width="120dp"
         android:height="120dp"
-        android:gravity="center" />
+        android:gravity="center" />-->
 
 </layer-list>

--- a/Ui/FitEdit.Ui.Infra/Supabase/SupabaseAdapter.cs
+++ b/Ui/FitEdit.Ui.Infra/Supabase/SupabaseAdapter.cs
@@ -622,11 +622,18 @@ public class SupabaseAdapter : ReactiveObject, ISupabaseAdapter
   public async Task<bool> DeleteAsync(LocalActivity? act)
   {
     if (act is null) { return false; }
-    
-    await client_.Postgrest.Table<Model.Activity>()
-      .Filter("Id", Postgrest.Constants.Operator.Equals, act.Id)
-      .Delete()
-      .AnyContext();
+
+    try
+    {
+      await client_.Postgrest.Table<Model.Activity>()
+        .Filter("Id", Postgrest.Constants.Operator.Equals, act.Id)
+        .Delete()
+        .AnyContext();
+    }
+    catch (HttpRequestException)
+    {
+      tasks_.NotifyUser("Error", "Could reach the server to delete the file.");
+    }
 
     if (Authorization?.Sub is null) { return false; }
 

--- a/Ui/FitEdit.Ui.iOS/Info.plist
+++ b/Ui/FitEdit.Ui.iOS/Info.plist
@@ -7,11 +7,11 @@
     <key>CFBundleIdentifier</key>
     <string>com.endurabyte.fitedit</string>
     <key>CFBundleShortVersionString</key>
-    <string>4.3.0</string>
+    <string>4.4.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true />
     <key>MinimumOSVersion</key>
-    <string>10.0</string>
+    <string>11.0</string>
     <key>UIDeviceFamily</key>
     <array>
       <integer>1</integer>
@@ -57,6 +57,6 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>32</string>
+    <string>33</string>
   </dict>
 </plist>


### PR DESCRIPTION
 Additive repair now ensures distance is cumulative.
 
  The distance of each record should be cumulative.
  If it is not, assume the discontinuity is due to a sketchy FIT file merge
  and repair it by making the distance cumulative.
  Return a new list of records; do not modify the given list.
  
  Algorithm:
  Assume the given records are sorted by timestamp.
  Iterate over all records from earliest to latest. 
  If a record's distance is less than the previous record's distance, 
  add the previous record's distance to the current record's distance.
