### PR TITLE
Add feature to split FIT files

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
     <Nullable>disable</Nullable>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>4.5.0</VersionPrefix>
-    <BuildIncrement>33</BuildIncrement>
+    <VersionPrefix>4.6.0</VersionPrefix>
+    <BuildIncrement>34</BuildIncrement>
     <VersionSuffix></VersionSuffix>
     <Product>FitEdit</Product>
     <Copyright>EnduraByte LLC 2024</Copyright>

--- a/Infrastructure/FitEdit.Data/IFileService.cs
+++ b/Infrastructure/FitEdit.Data/IFileService.cs
@@ -14,7 +14,7 @@ public interface IFileService
   /// <summary>
   /// Create a new file and file list entry for the given FIT file
   /// </summary>
-  Task CreateAsync(FitFile fit);
+  Task CreateAsync(FitFile fit, string? suffix = "");
   Task<bool> CreateAsync(LocalActivity? act, CancellationToken ct = default);
   Task<LocalActivity?> ReadAsync(string id, CancellationToken ct = default);
   Task<bool> UpdateAsync(LocalActivity? act, CancellationToken ct = default);

--- a/Infrastructure/FitEdit.Data/NullFileService.cs
+++ b/Infrastructure/FitEdit.Data/NullFileService.cs
@@ -70,7 +70,7 @@ public class NullFileService : IFileService
     return file;
   }
 
-  public Task CreateAsync(FitFile fit) => Task.CompletedTask;
+  public Task CreateAsync(FitFile fit, string? suffix) => Task.CompletedTask;
   public Task<bool> CreateAsync(LocalActivity? act, CancellationToken ct = default) => Task.FromResult(true);
   public Task<bool> DeleteAsync(LocalActivity? act) => Task.FromResult(true);
   public Task<List<string>> GetAllActivityIdsAsync(DateTime? after, DateTime? before) => Task.FromResult(new List<string>());

--- a/Ui/FitEdit.Ui.Infra/FileService.cs
+++ b/Ui/FitEdit.Ui.Infra/FileService.cs
@@ -45,7 +45,7 @@ public class FileService : ReactiveObject, IFileService
 
   private void InitFilesList() => _ = Task.Run(LoadMore);
   
-  public async Task CreateAsync(FitFile fit)
+  public async Task CreateAsync(FitFile fit, string? suffix = "(Edited)")
   { 
     UiFile? originalFile = MainFile;
 
@@ -56,7 +56,7 @@ public class FileService : ReactiveObject, IFileService
     };
 
     newFile.Activity.Id = $"{Guid.NewGuid()}";
-    newFile.Activity.Name = originalFile?.Activity?.Name + " (Edited)";
+    newFile.Activity.Name = $"{originalFile?.Activity?.Name} {suffix}";
     newFile.Activity.FileType = "fit";
     newFile.Activity.StartTime = fit.GetStartTime();
     newFile.Activity.File = new FileReference(newFile.Activity.Name, fit.GetBytes());
@@ -65,11 +65,11 @@ public class FileService : ReactiveObject, IFileService
     bool ok = await CreateAsync(newFile.Activity);
 
     // Make the new file the active one
-    await Dispatcher.UIThread.InvokeAsync(() =>
-    {
-      if (MainFile != null) { MainFile.IsLoaded = false; }
-      MainFile = newFile;
-    });
+    // await Dispatcher.UIThread.InvokeAsync(() =>
+    // {
+    //   if (MainFile != null) { MainFile.IsLoaded = false; }
+    //   MainFile = newFile;
+    // });
   }
 
   public async Task<bool> CreateAsync(LocalActivity? act, CancellationToken ct = default)

--- a/Ui/FitEdit.Ui.iOS/Info.plist
+++ b/Ui/FitEdit.Ui.iOS/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleIdentifier</key>
     <string>com.endurabyte.fitedit</string>
     <key>CFBundleShortVersionString</key>
-    <string>4.5.0</string>
+    <string>4.6.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true />
     <key>MinimumOSVersion</key>
@@ -57,6 +57,6 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>33</string>
+    <string>34</string>
   </dict>
 </plist>

--- a/Ui/FitEdit.Ui/ViewModels/RecordViewModel.cs
+++ b/Ui/FitEdit.Ui/ViewModels/RecordViewModel.cs
@@ -671,6 +671,18 @@ public class RecordViewModel : ViewModelBase, IRecordViewModel
     HaveUnsavedChanges = true;
   }
 
+  public async Task SplitActivity()
+  {
+    if (fitFile_ is null) { return; }
+    if (SelectedIndex == 0 || SelectedIndex == SelectionCount - 1) { return; }
+  
+    System.DateTime at = fitFile_.Records[SelectedIndex].InstantOfTime();
+    (FitFile first, FitFile second) = fitFile_.SplitAt(at);
+   
+    await fileService_.CreateAsync(first, "(Split 1)");
+    await fileService_.CreateAsync(second, "(Split 2)");
+  }
+
   private void HandleCellEditEnding(object? sender, DataGridCellEditEndingEventArgs e)
   {
     var dg = sender as DataGrid;

--- a/Ui/FitEdit.Ui/Views/RecordView.axaml
+++ b/Ui/FitEdit.Ui/Views/RecordView.axaml
@@ -18,51 +18,59 @@
   
   <Grid RowDefinitions="Auto, *, 5" ColumnDefinitions="3*, Auto">
 
-    <Expander Grid.Row="0" Grid.Column="0" Header="Filters">
-      <WrapPanel Orientation="Horizontal">
-        <CheckBox Content="Hide unused columns" IsChecked="{Binding HideUnusedFields}" Margin="0,0,20,0">
-          <ToolTip.Tip>
-            <TextBlock TextWrapping="Wrap">
-              Hide columns that have no data. For example, lat/lon for treadmill runs.
-            </TextBlock>
-          </ToolTip.Tip>
-        </CheckBox>
+    <StackPanel Orientation="Horizontal">
+      <Expander Grid.Row="0" Grid.Column="0" Header="Filters">
+        <WrapPanel Orientation="Horizontal">
+          <CheckBox Content="Hide unused columns" IsChecked="{Binding HideUnusedFields}" Margin="0,0,20,0">
+            <ToolTip.Tip>
+              <TextBlock TextWrapping="Wrap">
+                Hide columns that have no data. For example, lat/lon for treadmill runs.
+              </TextBlock>
+            </ToolTip.Tip>
+          </CheckBox>
 
-        <CheckBox Content="Hide unnamed columns" IsChecked="{Binding HideUnnamedFields}" Margin="0,0,20,0">
-          <ToolTip.Tip>
-            <TextBlock TextWrapping="Wrap">
-              Hide columns named like "Field #"
-            </TextBlock>
-          </ToolTip.Tip>
-        </CheckBox>
-        <CheckBox Content="Hide unnamed tabs" IsChecked="{Binding HideUnnamedMessages}" Margin="0,0,20,0">
-          <ToolTip.Tip>
-            <TextBlock TextWrapping="Wrap">
-              Hide tabs like "Message #"
-            </TextBlock>
-          </ToolTip.Tip>
-        </CheckBox>
-        <CheckBox Content="Pretty data" IsChecked="{Binding PrettifyFields}" Margin="0,0,20,0">
-          <ToolTip.Tip>
-            <TextBlock TextWrapping="Wrap">
-              Convert raw data to a more cosmetic format. Examples: <LineBreak/>
-              - Convert numbers like ActivityType "1" to "Running" <LineBreak/>
-              - Convert timestamps like 945518320 to "12/17/2019 11:58:40". The format depends on your region.<LineBreak/>
-              - Convert lat/lon like 427200580 to 35.80753896385431
-            </TextBlock>
-          </ToolTip.Tip>
-        </CheckBox>
-        <CheckBox Content="Hex view" IsChecked="{Binding ShowHexData}" Margin="0,0,20,0">
-          <ToolTip.Tip>
-            <TextBlock TextWrapping="Wrap">
-              Show hex data for the selected row <LineBreak/>
-              See https://developer.garmin.com/fit/protocol/ for the FIT protocol specification
-            </TextBlock>
-          </ToolTip.Tip>
-        </CheckBox>
-      </WrapPanel>
-    </Expander>
+          <CheckBox Content="Hide unnamed columns" IsChecked="{Binding HideUnnamedFields}" Margin="0,0,20,0">
+            <ToolTip.Tip>
+              <TextBlock TextWrapping="Wrap">
+                Hide columns named like "Field #"
+              </TextBlock>
+            </ToolTip.Tip>
+          </CheckBox>
+          <CheckBox Content="Hide unnamed tabs" IsChecked="{Binding HideUnnamedMessages}" Margin="0,0,20,0">
+            <ToolTip.Tip>
+              <TextBlock TextWrapping="Wrap">
+                Hide tabs like "Message #"
+              </TextBlock>
+            </ToolTip.Tip>
+          </CheckBox>
+          <CheckBox Content="Pretty data" IsChecked="{Binding PrettifyFields}" Margin="0,0,20,0">
+            <ToolTip.Tip>
+              <TextBlock TextWrapping="Wrap">
+                Convert raw data to a more cosmetic format. Examples: <LineBreak />
+                - Convert numbers like ActivityType "1" to "Running" <LineBreak />
+                - Convert timestamps like 945518320 to "12/17/2019 11:58:40". The format depends on your region.
+                <LineBreak />
+                - Convert lat/lon like 427200580 to 35.80753896385431
+              </TextBlock>
+            </ToolTip.Tip>
+          </CheckBox>
+          <CheckBox Content="Hex view" IsChecked="{Binding ShowHexData}" Margin="0,0,20,0">
+            <ToolTip.Tip>
+              <TextBlock TextWrapping="Wrap">
+                Show hex data for the selected row <LineBreak />
+                See https://developer.garmin.com/fit/protocol/ for the FIT protocol specification
+              </TextBlock>
+            </ToolTip.Tip>
+          </CheckBox>
+        </WrapPanel>
+      </Expander>
 
+      <Button Margin="0"
+        Command="{Binding SplitActivity}"
+        IsVisible="{Binding SelectedIndex > 0}"
+        Content="Split"/>
+    </StackPanel>
+    
     <TabControl Grid.Row="1" Grid.Column="0" ItemsSource="{Binding ShownData}" SelectedIndex="{Binding TabIndex}">
       <TabControl.ItemTemplate>
         <DataTemplate>


### PR DESCRIPTION
Added a Split button which splits a FIT file into two: before and including the selected record, and after the record to the end of the FIT file. 

Two activities are created with suffix (Split 1) and (Split 2).

<img width="254" alt="Screenshot 2024-08-15 at 11 16 39 PM" src="https://github.com/user-attachments/assets/cd1c2de9-1212-43fa-a032-5fc9ec9ced79">
