### PR TITLE
Fix bugs discovered when loading a file created by the Strava android app

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
     <Nullable>disable</Nullable>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>4.8.0</VersionPrefix>
-    <BuildIncrement>36</BuildIncrement>
+    <VersionPrefix>4.8.1</VersionPrefix>
+    <BuildIncrement>37</BuildIncrement>
     <VersionSuffix></VersionSuffix>
     <Product>FitEdit</Product>
     <Copyright>EnduraByte LLC 2024</Copyright>

--- a/Infrastructure/FitEdit.Adapters.Fit/Decode.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/Decode.cs
@@ -501,7 +501,8 @@ namespace Dynastream.Fit
 
           if (timeTraveled)
           {
-            Log.Warn($"Discarding suspicious message with timestamp change of {diff}s");
+            var dt = new RecordMesg(mesg).GetTimestamp().GetDateTime();
+            Log.Warn($"Discarding suspicious message at {dt} with timestamp change of {diff}s");
             Log.Debug($"Source data: {string.Join(" ", mesg.SourceData?.Select(b => $"{b:X2}") ?? new List<string>())}");
             return;
           }

--- a/Infrastructure/FitEdit.Data/Fit/FitFileExtensions.cs
+++ b/Infrastructure/FitEdit.Data/Fit/FitFileExtensions.cs
@@ -66,8 +66,16 @@ public static class FitFileExtensions
   /// Return only the <see cref="T"/>s which occur in the given <see cref="Dynastream.Fit.DateTime"/> range.
   /// Used for e.g. Records and other messages which don't span a duration of time and instead only occupy an instant in time.
   /// </summary>
-  public static IEnumerable<T> InstantBetween<T>(this IEnumerable<T> ts, Dynastream.Fit.DateTime after = default, Dynastream.Fit.DateTime before = default)
-    where T : IInstantOfTime => ts.Where(t => t.GetTimestamp().CompareTo(after) >= 0 && t.GetTimestamp().CompareTo(before) < 0);
+  public static IEnumerable<T> InstantBetween<T>(this IEnumerable<T> ts, 
+    Dynastream.Fit.DateTime after = default, 
+    Dynastream.Fit.DateTime before = default
+  ) where T : IInstantOfTime => ts.Where(t =>
+    {
+      var timestamp = t.GetTimestamp();
+      if (timestamp is null) { return false; }
+
+      return timestamp.CompareTo(after) >= 0 && timestamp.CompareTo(before) < 0;
+    });
 
   /// <summary>
   /// Compute Session, Records, and Laps from Events

--- a/Ui/FitEdit.Ui.iOS/Info.plist
+++ b/Ui/FitEdit.Ui.iOS/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleIdentifier</key>
     <string>com.endurabyte.fitedit</string>
     <key>CFBundleShortVersionString</key>
-    <string>4.8.0</string>
+    <string>4.8.1</string>
     <key>LSRequiresIPhoneOS</key>
     <true />
     <key>MinimumOSVersion</key>
@@ -57,6 +57,6 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>36</string>
+    <string>37</string>
   </dict>
 </plist>

--- a/Ui/FitEdit.Ui/ViewModels/FileViewModel.cs
+++ b/Ui/FitEdit.Ui/ViewModels/FileViewModel.cs
@@ -407,19 +407,6 @@ public class FileViewModel : ViewModelBase, IFileViewModel
       return;
     }
 
-    if (uif.FitFile != null) 
-    {
-      Log.Info($"File {uif.Activity.Name} is already loaded");
-      uif.Progress = 100;
-      uif.IsLoaded = true;
-
-      await Dispatcher.UIThread.InvokeAsync(() =>
-      {
-        FileService.MainFile = uif;
-      });
-      return;
-    }
-
     LocalActivity? act = await FileService.ReadAsync(uif.Activity.Id);
     FileReference? file = act?.File;
     uif.Activity.File = act?.File;


### PR DESCRIPTION
1. Ignore FileInfo messages with null timestamp
2. Log timestamp of discarded messages
3. Always reload the FIT file. So it can function as a poor man's undo.