### PR TITLE
Support multipart FIT files

### DIFF
--- a/Core/FitEdit.Model/Extensions/EnumerableExtensions.cs
+++ b/Core/FitEdit.Model/Extensions/EnumerableExtensions.cs
@@ -2,6 +2,8 @@
 
 public static class EnumerableExtensions
 {
+  public static bool IsAnyOf<T>(this T t, params T[] values) => values.Contains(t);
+
   public static Dictionary<TKey, TValue> ToDictionaryAllowDuplicateKeys<TKey, TValue, TEnum>(
     this IEnumerable<TEnum> e, 
     Func<TEnum, TKey> getKey, Func<TEnum, TValue> getValue)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
     <Nullable>disable</Nullable>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>4.9.0</VersionPrefix>
-    <BuildIncrement>38</BuildIncrement>
+    <VersionPrefix>5.0.0</VersionPrefix>
+    <BuildIncrement>39</BuildIncrement>
     <VersionSuffix></VersionSuffix>
     <Product>FitEdit</Product>
     <Copyright>EnduraByte LLC 2024</Copyright>

--- a/Infrastructure/FitEdit.Adapters.Fit/Decode.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/Decode.cs
@@ -12,6 +12,7 @@
 
 #endregion
 
+
 using FitEdit.Adapters.Fit;
 using FitEdit.Adapters.Fit.Extensions;
 using FitEdit.Model;
@@ -19,6 +20,7 @@ using FitEdit.Model.Extensions;
 
 namespace Dynastream.Fit
 {
+  public delegate void FitFileReadEventHandler();
 
   /// <summary>
   /// This class will decode a .fit file reading the file header and any definition or data messages.
@@ -28,20 +30,25 @@ namespace Dynastream.Fit
     private const long CRCSIZE = 2;
     private const uint INVALID_DATA_SIZE = 0;
 
-    private readonly MesgDefinition[] localMesgDefs_ = new MesgDefinition[Fit.MaxLocalMesgs];
-    private Header fileHeader_;
-    private uint timestamp_ = 0;
-    private int lastTimeOffset_ = 0;
-    private int lastLatitude_ = 0;
-    private int lastLongitude_ = 0;
-    private readonly Accumulator accumulator_ = new();
-    private readonly DeveloperDataLookup lookup_ = new();
+    private readonly MesgDefinition[] _localMesgDefs = new MesgDefinition[Fit.MaxLocalMesgs];
+    private uint _timestamp = 0;
+    private int _lastTimeOffset = 0;
+    private int _lastLatitude = 0;
+    private int _lastLongitude = 0;
+    private DecodeResult _lastResult = DecodeResult.Init;
+    private long _lastFileSize = 0;
+    private long _lastFilePosition = 0;
+    private Header _lastHeader = null!;
 
-    public bool InvalidDataSize { get; set; } = false;
+    private readonly Accumulator _accumulator = new();
+    private readonly DeveloperDataLookup _lookup = new();
+
+    public bool IsDataSizeInvalid { get; set; } = false;
 
     public event MesgEventHandler MesgEvent;
     public event MesgDefinitionEventHandler MesgDefinitionEvent;
     public event EventHandler<DeveloperFieldDescriptionEventArgs> DeveloperFieldDescriptionEvent;
+    public event FitFileReadEventHandler FitFileRead;
 
     /// <summary>
     /// Reads the file header to check if the file is FIT.
@@ -103,7 +110,7 @@ namespace Dynastream.Fit
           }
           else
           {
-            InvalidDataSize = true;
+            IsDataSizeInvalid = true;
             isValid = false;
           }
         }
@@ -124,12 +131,12 @@ namespace Dynastream.Fit
     /// <returns>
     /// Returns true if reading finishes successfully.
     /// </returns>
-    public async Task<bool> ReadAsync(Stream fitStream)
+    public async Task<DecodeResult> ReadAsync(Stream fitStream)
     {
-      bool status = true;
+      var status = DecodeResult.OkReadSomeMessages;
       long position = fitStream.Position;
 
-      while ((fitStream.Position < fitStream.Length) && status)
+      while ((fitStream.Position < fitStream.Length) && status != DecodeResult.ErrEndOfStream)
       {
         status = await ReadAsync(fitStream, DecodeMode.Normal);
       }
@@ -138,7 +145,6 @@ namespace Dynastream.Fit
 
       return status;
     }
-
 
     /// <summary>
     /// Reads a FIT binary File
@@ -149,38 +155,28 @@ namespace Dynastream.Fit
     /// <returns>
     /// Returns true if reading finishes successfully.
     /// </returns>
-    public async Task<bool> ReadAsync(Stream fitStream, DecodeMode mode, int messageCount = -1)
+    public async Task<DecodeResult> ReadAsync(Stream fitStream, DecodeMode mode, int messageCount = -1)
     {
       if (messageCount < 0) messageCount = int.MaxValue;
 
-      long fileSize = fitStream.Length;
-      long filePosition = fitStream.Position;
+      // Require stream to be at start for initial read
+      if (_lastResult == DecodeResult.Init && fitStream.Position != 0)
+      {
+        _lastResult = DecodeResult.ErrInitialRead;
+        return _lastResult;
+      }
 
       try
       {
-        bool fileOk = true;
-
         // Attempt to read header
-        if (filePosition == 0 && (mode == DecodeMode.Normal || mode == DecodeMode.Partial))
+        if (mode == DecodeMode.Normal)
         {
-          fileHeader_ = new Header(fitStream);
-          fileOk &= fileHeader_.IsValid();
+          if (_lastResult == DecodeResult.Init || _lastResult == DecodeResult.OkEndOfFile)
+          {
+            Header header = ParseHeader(fitStream, IsDataSizeInvalid, out _lastFileSize);
 
-          // Get the file size from the header
-          // When the data size is invalid set the file size to the fitstream length
-          if (!InvalidDataSize)
-          {
-            fileSize = fileHeader_.Size + fileHeader_.DataSize + CRCSIZE;
-          }
-
-          if (!fileOk)
-          {
-            throw new FitException("FIT decode error: File is not FIT format. Check file header data type. Error at stream position: " + fitStream.Position);
-          }
-          if ((fileHeader_.ProtocolVersion & Fit.ProtocolVersionMajorMask) > (Fit.ProtocolMajorVersion << Fit.ProtocolVersionMajorShift))
-          {
-            // The decoder does not support decode accross protocol major revisions
-            throw new FitException($"FIT decode error: Protocol Version {(fileHeader_.ProtocolVersion & Fit.ProtocolVersionMajorMask) >> Fit.ProtocolVersionMajorShift}.X not supported by SDK Protocol Ver{Fit.ProtocolMajorVersion}.{Fit.ProtocolMinorVersion} ");
+            _lastHeader = header;
+            _lastFilePosition = fitStream.Position;
           }
         }
         else if (mode == DecodeMode.InvalidHeader)
@@ -188,64 +184,96 @@ namespace Dynastream.Fit
           // When skipping the header force the stream position to be at the beginning of the data
           // Also the fileSize is the length of the filestream.
           fitStream.Position += Fit.HeaderWithCRCSize;
-          fileSize = fitStream.Length;
+          _lastFileSize = fitStream.Length;
         }
         else if (mode == DecodeMode.DataOnly)
         {
           // When the stream is only data move the position of the stream
           // to the start. FileSize is the length of the stream
           fitStream.Position = 0;
-          fileSize = fitStream.Length;
-        }
-        else if (mode == DecodeMode.Partial)
-        {
-        }
-        else
-        {
-          throw new FitException("Invalid Decode Mode Provided to read");
+          _lastFileSize = fitStream.Length;
         }
 
-        long end = fileSize - CRCSIZE;
+        long end = _lastFilePosition + _lastFileSize - CRCSIZE - _lastHeader.Size;
 
-        // Read n data messages and definitions
-        if (mode == DecodeMode.Partial)
+        // Read up to n messages
+        foreach (int i in Enumerable.Range(0, messageCount))
         {
-          int count = 0;
-          while (fitStream.Position < end && count < messageCount)
+          if (fitStream.Position >= end)
           {
-            DecodeNextMessage(fitStream);
-            count++;
+            FitFileRead?.Invoke();
+            break;
           }
-          return fitStream.Position < end;
-        }
 
-        // Read all data messages and definitions
-        while (fitStream.Position < end)
-        {
           DecodeNextMessage(fitStream);
         }
 
-        // Is the file CRC ok?
-        if ((mode == DecodeMode.Normal) && !InvalidDataSize)
+        _lastResult = fitStream.Position >= end
+          ? DecodeResult.OkEndOfFile
+          : DecodeResult.OkReadSomeMessages;
+
+        if (_lastResult != DecodeResult.OkEndOfFile || mode != DecodeMode.Normal || IsDataSizeInvalid)
         {
-          byte[] data = new byte[fileSize];
-          fitStream.Position = filePosition;
-          await fitStream.ReadAsync(data, 0, data.Length);
-          fileOk &= (CRC.Calc16(data, data.Length) == 0x0000);
-          fitStream.Position = filePosition + fileSize;
+          return _lastResult;
         }
 
-        return fileOk;
+        // Is the file CRC ok?
+        bool crcOK = await ReadCrc(fitStream, _lastFileSize, _lastFilePosition, _lastHeader.Size);
+
+        return crcOK
+          ? _lastResult
+          : DecodeResult.ErrCrc;
       }
       catch (EndOfStreamException e)
       {
         Log.Error(e.Message);
-        return false; // Done reading
+        return DecodeResult.ErrEndOfStream; // Done reading
       }
       catch (FitException e)
       {
         Log.Error(e.Message);
-        return true; // Attempt to keep reading
+        return DecodeResult.ErrFitException; // Attempt to keep reading
+      }
+    }
+
+    private static async Task<bool> ReadCrc(Stream fitStream, long fileSize, long filePosition, int headerSize)
+    {
+      var data = new byte[fileSize];
+      fitStream.Position = filePosition;
+      await fitStream.ReadAsync(data, 0, data.Length);
+      bool crcOK = CRC.Calc16(data, data.Length) == 0x0000;
+      fitStream.Position = filePosition + fileSize - headerSize;
+      return crcOK;
+    }
+
+    private static Header ParseHeader(Stream fitStream, bool isDataSizeInvalid, out long fileSize)
+    {
+      var header = new Header(fitStream);
+
+      // Get the file size from the header
+      // When the data size is invalid set the file size to the fitstream length
+      fileSize = isDataSizeInvalid switch
+      {
+        true => fitStream.Length,
+        false => header.Size + header.DataSize + CRCSIZE,
+      };
+
+      RequireValidFile(header, fitStream);
+
+      return header;
+    }
+
+    private static void RequireValidFile(Header header, Stream fitStream)
+    {
+      bool isValid = header.IsValid();
+      if (!isValid)
+      {
+        throw new FitException("FIT decode error: File is not FIT format. Check file header data type. Error at stream position: " + fitStream.Position);
+      }
+      if ((header.ProtocolVersion & Fit.ProtocolVersionMajorMask) > (Fit.ProtocolMajorVersion << Fit.ProtocolVersionMajorShift))
+      {
+        // The decoder does not support decode accross protocol major revisions
+        throw new FitException($"FIT decode error: Protocol Version {(header.ProtocolVersion & Fit.ProtocolVersionMajorMask) >> Fit.ProtocolVersionMajorShift}.X not supported by SDK Protocol Ver{Fit.ProtocolMajorVersion}.{Fit.ProtocolMinorVersion} ");
       }
     }
 
@@ -297,12 +325,12 @@ namespace Dynastream.Fit
       byte localMesgNum = (byte)(nextByte & Fit.LocalMesgNumMask);
 
       mesgBuffer.WriteByte(localMesgNum);
-      if (localMesgDefs_[localMesgNum] == null)
+      if (_localMesgDefs[localMesgNum] == null)
       {
         throw new FitException($"FIT decode error: Missing message definition for local message number {localMesgNum} at stream position {fitStream.Position}");
       }
 
-      MesgDefinition def = localMesgDefs_[localMesgNum];
+      MesgDefinition def = _localMesgDefs[localMesgNum];
       Log.Debug($"  (global, local) message num: ({localMesgNum}, {def.GlobalMesgNum})");
       int fieldsSize = def.GetMesgSize() - 1;
 
@@ -347,8 +375,8 @@ namespace Dynastream.Fit
       {
         // Detect big jump in latitude
         var lat = (int)latitudeField.GetValue();
-        var diff = Math.Abs(lat - lastLatitude_);
-        bool suspicious = lastLatitude_ != 0 && diff > GeospatialExtensions.DegreeToSemicircles;
+        var diff = Math.Abs(lat - _lastLatitude);
+        bool suspicious = _lastLatitude != 0 && diff > GeospatialExtensions.DegreeToSemicircles;
 
         if (suspicious)
         {
@@ -357,7 +385,7 @@ namespace Dynastream.Fit
           return;
         }
 
-        lastLatitude_ = lat;
+        _lastLatitude = lat;
       }
 
       if (FitConfig.Discard.DataMessages.WithLargeLongitudeChange
@@ -365,8 +393,8 @@ namespace Dynastream.Fit
       {
         // Detect big jump in longitude
         var lon = (int)longitudeField.GetValue();
-        var diff = Math.Abs(lon - lastLongitude_);
-        bool suspicious = lastLongitude_ != 0 && diff > GeospatialExtensions.DegreeToSemicircles;
+        var diff = Math.Abs(lon - _lastLongitude);
+        bool suspicious = _lastLongitude != 0 && diff > GeospatialExtensions.DegreeToSemicircles;
 
         if (suspicious)
         {
@@ -375,15 +403,15 @@ namespace Dynastream.Fit
           return;
         }
 
-        lastLongitude_ = lon;
+        _lastLongitude = lon;
       }
 
       if (FitConfig.Discard.DataMessages.WithLargeTimestampChange
         && haveTimestamp && haveLongitude && haveLongitude)
       {
         var ts = (uint)timestampField.GetValue();
-        var diff = Math.Abs((int)ts - (int)timestamp_);
-        bool timeTraveled = timestamp_ > 0 && diff > TimeSpan.FromDays(1).TotalSeconds;
+        var diff = Math.Abs((int)ts - (int)_timestamp);
+        bool timeTraveled = _timestamp > 0 && diff > TimeSpan.FromDays(1).TotalSeconds;
 
         if (timeTraveled)
         {
@@ -393,15 +421,15 @@ namespace Dynastream.Fit
           return;
         }
 
-        timestamp_ = ts;
-        lastTimeOffset_ = (int)timestamp_ & Fit.CompressedTimeMask;
+        _timestamp = ts;
+        _lastTimeOffset = (int)_timestamp & Fit.CompressedTimeMask;
       }
 
       if (FitConfig.Discard.DataMessages.UnexpectedFileIdMessage
         && mesg is FileIdMesg && fitStream.Position > 1024)
       {
         Log.Warn($"Discarding suspicious FileID message.");
-        fitStream.Position = FindNextMessageByTimestamp(timestamp_, fitStream);
+        fitStream.Position = FindNextMessageByTimestamp(_timestamp, fitStream);
         return;
       }
 
@@ -428,13 +456,13 @@ namespace Dynastream.Fit
                 }
               }
             }
-            accumulator_.Set(mesg.Num, field.Num, value);
+            _accumulator.Set(mesg.Num, field.Num, value);
           }
         }
       }
 
       // Now that the entire message is decoded we can evaluate subfields and expand any components
-      mesg.ExpandComponents(accumulator_);
+      mesg.ExpandComponents(_accumulator);
 
       RaiseMesgEvent(mesg);
       return;
@@ -492,14 +520,14 @@ namespace Dynastream.Fit
         mesgDefBuffer.Write(read, 0, numBytes);
       }
 
-      var def = new MesgDefinition(mesgDefBuffer, lookup_)
+      var def = new MesgDefinition(mesgDefBuffer, _lookup)
       {
         SourceIndex = sourceIndex,
       };
 
       if (FitConfig.Discard.DefinitionMessages.RedefiningGlobalMesgNum
-        && localMesgDefs_[def.LocalMesgNum] != null
-        && localMesgDefs_[def.LocalMesgNum].GlobalMesgNum != def.GlobalMesgNum)
+        && _localMesgDefs[def.LocalMesgNum] != null
+        && _localMesgDefs[def.LocalMesgNum].GlobalMesgNum != def.GlobalMesgNum)
       {
         Log.Warn($"Discarding suspicious redefinition of local mesg def with different global mesg num");
         Log.Debug($"Source data: {string.Join(" ", def.SourceData?.Select(b => $"{b:X2}") ?? new List<string>())}");
@@ -522,7 +550,7 @@ namespace Dynastream.Fit
         return;
       }
 
-      localMesgDefs_[def.LocalMesgNum] = def;
+      _localMesgDefs[def.LocalMesgNum] = def;
       MesgDefinitionEvent?.Invoke(this, new MesgDefinitionEventArgs(def));
     }
 
@@ -531,18 +559,18 @@ namespace Dynastream.Fit
       var mesgBuffer = new MemoryStream();
 
       int timeOffset = nextByte & Fit.CompressedTimeMask;
-      timestamp_ += (uint)((timeOffset - lastTimeOffset_) & Fit.CompressedTimeMask);
-      lastTimeOffset_ = timeOffset;
+      _timestamp += (uint)((timeOffset - _lastTimeOffset) & Fit.CompressedTimeMask);
+      _lastTimeOffset = timeOffset;
       Field timestampField = new Field(Profile.GetMesg(MesgNum.Record).GetField("Timestamp"));
-      timestampField.SetValue(timestamp_);
+      timestampField.SetValue(_timestamp);
 
       byte localMesgNum = (byte)((nextByte & Fit.CompressedLocalMesgNumMask) >> 5);
       mesgBuffer.WriteByte(localMesgNum);
-      if (localMesgDefs_[localMesgNum] == null)
+      if (_localMesgDefs[localMesgNum] == null)
       {
         throw new FitException($"FIT decode error: Missing message definition for local message number {localMesgNum} at stream position {fitStream.Position}");
       }
-      int fieldsSize = localMesgDefs_[localMesgNum].GetMesgSize() - 1;
+      int fieldsSize = _localMesgDefs[localMesgNum].GetMesgSize() - 1;
       try
       {
         byte[] read = br.ReadBytes(fieldsSize);
@@ -557,7 +585,7 @@ namespace Dynastream.Fit
         throw new FitException($"Compressed Data Message unexpected end of file. Wanted {fieldsSize} bytes at stream position {fitStream.Position}", e);
       }
 
-      var mesg = new Mesg(mesgBuffer, localMesgDefs_[localMesgNum])
+      var mesg = new Mesg(mesgBuffer, _localMesgDefs[localMesgNum])
       {
         SourceIndex = sourceIndex
       };
@@ -567,7 +595,7 @@ namespace Dynastream.Fit
         && mesg.Num == MesgNum.FileId && fitStream.Position > 1024)
       {
         Log.Warn($"Discarding suspicious FileID compressed header message.");
-        fitStream.Position = FindNextMessageByTimestamp(timestamp_, fitStream);
+        fitStream.Position = FindNextMessageByTimestamp(_timestamp, fitStream);
         return;
       }
 
@@ -631,12 +659,12 @@ namespace Dynastream.Fit
       if (newMesg.Num == MesgNum.DeveloperDataId)
       {
         var mesg = new DeveloperDataIdMesg(newMesg);
-        lookup_.Add(mesg);
+        _lookup.Add(mesg);
       }
       else if (newMesg.Num == MesgNum.FieldDescription)
       {
         var mesg = new FieldDescriptionMesg(newMesg);
-        DeveloperFieldDescription desc = lookup_.Add(mesg);
+        DeveloperFieldDescription desc = _lookup.Add(mesg);
         if (desc != null)
         {
           OnDeveloperFieldDescriptionEvent(

--- a/Infrastructure/FitEdit.Adapters.Fit/DecodeMode.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/DecodeMode.cs
@@ -33,12 +33,5 @@ namespace Dynastream.Fit
         /// Indicates that the Stream does not contain a Header or CRC
         /// </summary>
         DataOnly,
-
-        /// <summary>
-        /// Added by FitEdit.
-        /// Indicates that we should only read part of the stream.
-        /// The stream position might be nonzero if messages have already been decoded.
-        /// </summary>
-        Partial,
     }
 }

--- a/Infrastructure/FitEdit.Adapters.Fit/Extensions/DecodeResult.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/Extensions/DecodeResult.cs
@@ -1,0 +1,13 @@
+﻿namespace FitEdit.Adapters.Fit.Extensions;
+
+public enum DecodeResult
+{
+  Init,
+  OkReadSomeMessages,
+  OkEndOfFile, // A stream can contain multiple FIT files
+  ErrEndOfStream,
+  ErrFitException,
+  ErrInitialRead,
+  ErrCrc,
+}
+

--- a/Infrastructure/FitEdit.Adapters.Fit/Extensions/FieldTools.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/Extensions/FieldTools.cs
@@ -39,7 +39,7 @@ public static class FieldTools
       if (utf8Bytes.Count != 0)
       {
         // Add a Null Terminator
-        utf8Bytes.Add(0);
+        //utf8Bytes.Add(0);
         field.AddValue(utf8Bytes.ToArray());
         utf8Bytes.Clear();
       }

--- a/Infrastructure/FitEdit.Adapters.Fit/Header.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/Header.cs
@@ -113,25 +113,19 @@ namespace Dynastream.Fit
         public void Read(Stream fitStream)
         {
             BinaryReader binReader = new BinaryReader(fitStream);
-            try
+
+            Size = binReader.ReadByte();
+            ProtocolVersion = binReader.ReadByte();
+            ProfileVersion = binReader.ReadUInt16();
+            DataSize = binReader.ReadUInt32();
+            dataType = binReader.ReadChars(4);
+            if (Size == Fit.HeaderWithCRCSize)
             {
-                Size = binReader.ReadByte();
-                ProtocolVersion = binReader.ReadByte();
-                ProfileVersion = binReader.ReadUInt16();
-                DataSize = binReader.ReadUInt32();
-                dataType = binReader.ReadChars(4);
-                if (Size == Fit.HeaderWithCRCSize)
-                {
-                    Crc = binReader.ReadUInt16();
-                }
-                else
-                {
-                    Crc = 0x0000;
-                }
+                Crc = binReader.ReadUInt16();
             }
-            catch (EndOfStreamException e)
+            else
             {
-                throw new FitException("Header:Read() Failed at byte " + fitStream.Position + " - ", e);
+                Crc = 0x0000;
             }
         }
 

--- a/Infrastructure/FitEdit.Adapters.Fit/MesgDefinition.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/MesgDefinition.cs
@@ -212,14 +212,19 @@ namespace Dynastream.Fit
       bw.Write(Fit.MesgDefinitionReserved);
       bw.Write(Fit.LittleEndian);
       bw.Write(GlobalMesgNum);
-      bw.Write(NumFields);
+
+      // Garmin considers message definition fields with zero size to be invalid
+      var defsWithData = fieldDefs.Where(def => def.Size > 0).ToList();
+      var devDefsWithData = m_devFieldDefs.Where(def => def.Size > 0).ToList();
+
+      bw.Write((byte)defsWithData.Count);
 
       if (NumFields != fieldDefs.Count)
       {
         throw new FitException("MesgDefinition:Write - Field Count Internal Error");
       }
 
-      foreach (FieldDefinition def in fieldDefs)
+      foreach (FieldDefinition def in defsWithData)
       {
         bw.Write(def.Num);
         bw.Write(def.Size);
@@ -228,10 +233,10 @@ namespace Dynastream.Fit
 
       if (NumDevFields > 0)
       {
-        bw.Write(NumDevFields);
+        bw.Write((byte)devDefsWithData.Count);
       }
 
-      foreach (DeveloperFieldDefinition def in m_devFieldDefs)
+      foreach (DeveloperFieldDefinition def in devDefsWithData)
       {
         bw.Write(def.FieldNum);
         bw.Write(def.Size);

--- a/Infrastructure/FitEdit.Adapters.Fit/Profile.cs
+++ b/Infrastructure/FitEdit.Adapters.Fit/Profile.cs
@@ -17,6 +17,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.IO;
+using System.Runtime.CompilerServices;
 
 namespace Dynastream.Fit
 {
@@ -265,6 +266,12 @@ namespace Dynastream.Fit
             if(null != mesg)
             {
                 return mesg.GetField(fieldNum);
+            }
+
+            if (fieldNum == 253)
+            {
+              // Most 253 messages are timestamps
+              return new Field("Timestamp", 253, 134, 1, 0, "s", false, Type.DateTime);
             }
 
             return new Field("unknown", fieldNum, 0, 1, 0, "", false, Type.Enum);

--- a/Infrastructure/FitEdit.Data/Fit/Reader.cs
+++ b/Infrastructure/FitEdit.Data/Fit/Reader.cs
@@ -3,159 +3,149 @@ using FitEdit.Model;
 using Dynastream.Fit;
 using FitEdit.Adapters.Fit.Extensions;
 
-namespace FitEdit.Data.Fit
+namespace FitEdit.Data.Fit;
+
+public class Reader
 {
-  public class Reader
+  public async Task<List<FitFile>> ReadAsync(string source)
   {
-    public async Task<FitFile> ReadAsync(string source)
+    Log.Info($"Opening {source}...");
+    using var stream = new FileStream(source, FileMode.Open, FileAccess.Read, FileShare.Read);
+    return await ReadAsync(stream);
+  }
+
+  public async Task<List<FitFile>> ReadAsync(Stream stream)
+  {
+    if (!TryGetDecoder(stream, out List<FitFile> fitFiles, out Decode decoder))
     {
-      Log.Info($"Opening {source}...");
-      using var stream = new FileStream(source, FileMode.Open, FileAccess.Read, FileShare.Read);
-      return await ReadAsync(stream);
+      return [];
     }
 
-    public async Task<FitFile> ReadAsync(Stream stream)
+    try
     {
-      if (!TryGetDecoder(stream, out FitFile fitFile, out Decode decoder))
+      if (!decoder.CheckIntegrity(stream))
       {
-        return new FitFile();
+        Log.Warn($"Integrity Check failed...");
+        if (decoder.IsDataSizeInvalid)
+        {
+          Log.Warn("Invalid Size detected...");
+        }
+
+        Log.Warn("Attempting to read by skipping the header...");
+        var result = await decoder.ReadAsync(stream, DecodeMode.InvalidHeader);
+        if (result != DecodeResult.OkEndOfFile)
+        {
+          Log.Error($"Could not read FIT file by skipping the header");
+          return null;
+        }
       }
 
-      try
       {
-        if (!decoder.CheckIntegrity(stream))
-        {
-          Log.Warn($"Integrity Check failed...");
-          if (decoder.InvalidDataSize)
-          {
-            Log.Warn("Invalid Size detected...");
-          }
-
-          Log.Warn("Attempting to read by skipping the header...");
-          if (!await decoder.ReadAsync(stream, DecodeMode.InvalidHeader))
-          {
-            Log.Error($"Could not read FIT file by skipping the header");
-            return null;
-          }
-        }
-        if (!await decoder.ReadAsync(stream))
+        var result = await decoder.ReadAsync(stream);
+        if (result != DecodeResult.OkEndOfFile)
         {
           Log.Error($"Could not read FIT file");
           return null;
         }
+      }
 
-        Log.Info($"Found {fitFile.Messages.Count} messages");
+      foreach (var fitFile in fitFiles)
+      {
+        Log.Info($"Found {fitFile.Messages.Count} messages and {fitFile.MessageDefinitions.Count} definitions");
         fitFile.ForwardfillEvents();
-        return fitFile;
-
       }
-      catch (Exception ex)
-      {
-        Log.Error(ex.Message);
-        return null;
-      }
+      return fitFiles;
     }
-
-    /// <summary>
-    /// Read just one FIT message. Return false on error or end of stream.
-    /// This gives single-threaded environments such as WASM a chance to update the UI,
-    /// for example to show a progress bar or a message to the user.
-    /// </summary>
-    public async Task<bool> ReadOneAsync(Stream stream, Decode decoder, int messageCount = 1)
+    catch (Exception ex)
     {
-      try
-      {
-        return stream.Position switch
-        {
-          _ when stream.Position >= stream.Length => false,
-          _ => await decoder.ReadAsync(stream, DecodeMode.Partial, messageCount)
-        };
-      }
-      catch (FitException e)
-      {
-        Log.Error($"{e}");
-        return true; // Keep reading despite exception
-      }
-    }
-
-    public bool TryGetDecoder(Stream stream, out FitFile fit, out Decode decoder)
-    {
-      decoder = new Decode();
-      var tmp = new FitFile();
-
-      decoder.MesgEvent += (o, s) =>
-      {
-        if (Debugger.IsAttached)
-        {
-          Log.Debug($"Found {nameof(Mesg)} \'{s.mesg.Name}\'. (Num, LocalNum) = ({s.mesg.Num}, {s.mesg.LocalNum}).");
-          Log.Debug($"  Fields:");
-          Log.Debug($"    FieldNum\t Name\t Data:");
-          Log.Debug($"    {string.Join("\n    ", s.mesg.Fields.Values
-                            .Select(field => $"{field.Num}\t " +
-                                             $"\'{field.Name}\'\t " +
-                                             $"{string.Join(" ", field.SourceData?.Select(b => $"{b:X2}") ?? new List<string>())}"))}"
-          );
-
-          Log.Debug(s.PrintBytes());
-        }
-
-        var mesg = MessageFactory.Create(s.mesg);
-
-        if (!tmp.MessagesByDefinition.ContainsKey(mesg.Num))
-        {
-          tmp.MessagesByDefinition[mesg.Num] = new List<Mesg>() { mesg };
-        }
-        else
-        {
-          tmp.MessagesByDefinition[mesg.Num].Add(mesg);
-        }
-
-        tmp.Events.Add(new MesgEventArgs { mesg = mesg });
-      };
-
-      decoder.MesgDefinitionEvent += (o, s) =>
-      {
-        if (Debugger.IsAttached)
-        {
-          Log.Debug($"Found {nameof(MesgDefinition)}. (GlobalMesgNum, LocalMesgNum) = ({s.mesgDef.GlobalMesgNum}, {s.mesgDef.LocalMesgNum}).");
-
-          int fieldIndex = 0;
-          Log.Debug($"  Field Definitions");
-          Log.Debug($"    FieldIndex\t Num\t Size\t Type\t TypeName\t FieldName\t (Hex Values)");
-          Log.Debug($"    {string.Join("\n    ", s.mesgDef.GetFields()
-              .Select(fieldDef => $"{fieldIndex++}\t " +
-                                  $"{fieldDef.Num}\t " +
-                                  $"{fieldDef.Size}\t " +
-                                  $"{fieldDef.Type}\t " +
-                                  $"{(FitTypes.TypeMap.TryGetValue(fieldDef.Type, out var type) ? type.typeName : "Unknown Type")}\t " +
-                                  $"\'{Profile.GetField(s.mesgDef.GlobalMesgNum, fieldDef.Num)?.Name ?? "Unknown Field"}\'\t " +
-                                  $"({fieldDef.Num:X2} {fieldDef.Size:X2} {fieldDef.Type:X2})"))}");
-
-          Log.Debug(s.PrintBytes());
-        }
-        tmp.MessageDefinitions[s.mesgDef.GlobalMesgNum] = s.mesgDef;
-        tmp.Events.Add(s);
-      };
-
-      decoder.DeveloperFieldDescriptionEvent += (o, s) =>
-      {
-        Log.Debug($"Found {nameof(DeveloperFieldDescription)}. (ApplicationId, ApplicationVersion, FieldDefinitionNumber) = ({s.Description.ApplicationId}, {s.Description.ApplicationVersion}, {s.Description.FieldDefinitionNumber}");
-        Log.Debug(s.PrintBytes());
-        tmp.Events.Add(s);
-      };
-
-      bool ok = Decode.IsFIT(stream);
-      ok &= decoder.CheckIntegrity(stream);
-
-      if (!Decode.IsFIT(stream))
-      {
-        Log.Error($"File is not a FIT file");
-        fit = null;
-        return false;
-      }
-
-      fit = tmp;
-      return true; // Ignore integrity check
+      Log.Error(ex.Message);
+      return null;
     }
   }
+
+  /// <summary>
+  /// Read the given number of FIT messages. Return false on error or end of stream.
+  /// This gives single-threaded environments such as WASM a chance to update the UI,
+  /// for example to show a progress bar or a message to the user.
+  /// </summary>
+  public static async Task<DecodeResult> ReadSomeAsync(Stream stream, Decode decoder, int messageCount = 1)
+  {
+    try
+    {
+      return await decoder.ReadAsync(stream, DecodeMode.Normal, messageCount);
+    }
+    catch (FitException e)
+    {
+      Log.Error($"{e}");
+      return DecodeResult.ErrFitException; // Keep reading despite exception
+    }
+  }
+
+  public bool TryGetDecoder(Stream stream, out List<FitFile> fits, out Decode decoder)
+  {
+    decoder = new Decode();
+    fits = [];
+    var fitsTemp = new List<FitFile>();
+    var tmp = new FitFile();
+
+    decoder.FitFileRead += () =>
+    {
+      Log.Debug($"Read FIT file with {tmp.Events.Count} messages");
+      fitsTemp.Add(tmp);
+      tmp = new FitFile();
+    };
+
+    int count = 0;
+    decoder.MesgEvent += (o, s) =>
+    {
+      Log.Debug($"Read record {count++}");
+      s.DebugLog();
+
+      var mesg = MessageFactory.Create(s.mesg);
+
+      if (!tmp.MessagesByDefinition.ContainsKey(mesg.Num))
+      {
+        tmp.MessagesByDefinition[mesg.Num] = new List<Mesg>() { mesg };
+      }
+      else
+      {
+        tmp.MessagesByDefinition[mesg.Num].Add(mesg);
+      }
+
+      tmp.Events.Add(new MesgEventArgs { mesg = mesg });
+    };
+
+    decoder.MesgDefinitionEvent += (o, s) =>
+    {
+      Log.Debug($"Read record {count++}");
+      s.DebugLog();
+
+      tmp.MessageDefinitions[s.mesgDef.GlobalMesgNum] = s.mesgDef;
+      tmp.Events.Add(s);
+    };
+
+    decoder.DeveloperFieldDescriptionEvent += (o, s) =>
+    {
+      Log.Debug($"Read record {count++}");
+      s.DebugLog();
+
+      tmp.Events.Add(s);
+    };
+
+    bool ok = Decode.IsFIT(stream);
+    ok &= decoder.CheckIntegrity(stream);
+
+    if (!Decode.IsFIT(stream))
+    {
+      Log.Error($"File is not a FIT file");
+      return false;
+    }
+
+    fits = fitsTemp;
+    return true; // Ignore integrity check
+  }
+}
+
+public static class FitLog
+{ 
 }

--- a/Infrastructure/FitEdit.Data/Fit/Writer.cs
+++ b/Infrastructure/FitEdit.Data/Fit/Writer.cs
@@ -17,30 +17,48 @@ namespace FitEdit.Data.Fit
       Log.Info($"Finished writing {destination}");
     }
 
+    public void Write(IEnumerable<FitFile> files, Stream dest)
+    {
+      foreach (var fitFile in files)
+      {
+        var tmpStream = new MemoryStream();
+        Write(fitFile, tmpStream);
+        tmpStream.Position = 0;
+        tmpStream.CopyTo(dest);
+      }
+    }
+
     public void Write(FitFile fitFile, Stream dest)
     {
       var encoder = new Encode(dest, ProtocolVersion.V20);
 
-      // Preserve the original message order
-      foreach (var message in fitFile.Events)
-      {
-        Action write = message switch
-        {
-          _ when message is MesgEventArgs args => () => encoder.Write(args.mesg),
-          _ when message is MesgDefinitionEventArgs args => () => encoder.Write(args.mesgDef),
-          _ => () => { },
-        };
+      int count = 0;
 
-        try
+      try
+      {
+        // Preserve the original message order
+        foreach (var message in fitFile.Events)
         {
-          write();
-        }
-        catch (Exception e)
-        {
-          Log.Error(e.Message);
+          Log.Debug($"Writing record {count++}");
+
+          if (message is MesgEventArgs mesgArgs)
+          {
+            mesgArgs.DebugLog();
+            encoder.Write(mesgArgs.mesg);
+          }
+
+          else if (message is MesgDefinitionEventArgs mesgDefArgs)
+          {
+            mesgDefArgs.DebugLog();
+            encoder.Write(mesgDefArgs.mesgDef);
+          }
+
         }
       }
-
+      catch (Exception e)
+      {
+        Log.Error(e.Message);
+      }
       Log.Info($"Wrote {fitFile.Messages.Count} messages and {fitFile.MessageDefinitions.Count} definitions");
       encoder.Close();
     }

--- a/Tests/FitEdit.Data.IntegrationTests/Writer/WriteMethod.cs
+++ b/Tests/FitEdit.Data.IntegrationTests/Writer/WriteMethod.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using FitEdit.Data.Fit;
 using FitEdit.Model.Data;
 using FitEdit.UnitTests.Shared;
@@ -9,7 +8,7 @@ using Writer = Fit.Writer;
 
 public class WriteMethod
 {
-  private const string source_ = @"..\..\..\..\TestData\2019-12-17-treadmill-run.fit";
+  private const string source_ = @"..\..\..\..\TestData\15535326668_ACTIVITY.fit";
 
   /// <summary>
   /// Verify round trip integrity, i.e. encode(decode(file)) == file
@@ -22,13 +21,16 @@ public class WriteMethod
     var ms1 = new MemoryStream(bytes);
     var ms2 = new MemoryStream();
 
-    var fitFile = await new Reader().ReadAsync(ms1);
-    new Writer().Write(fitFile, ms2);
+    var fitFiles = await new Reader().ReadAsync(ms1);
+    new Writer().Write(fitFiles, ms2);
 
     ms2.Position = 0;
-    var fitFile2 = await new Reader().ReadAsync(ms2);
+    var fitFiles2 = await new Reader().ReadAsync(ms2);
 
-    FitAssert.AreEqual(fitFile, fitFile2);
+    foreach (int i in Enumerable.Range(0, fitFiles.Count))
+    {
+      FitAssert.AreEqual(fitFiles[i], fitFiles2[i]);
+    }
   }
 
   [Fact]
@@ -45,14 +47,18 @@ public class WriteMethod
     FitAssert.AreEquivalentExceptHeader(ms2, bytes);
   }
 
+  /// <summary>
+  /// Assumes only one FIT file in the stream
+  /// </summary>
+  /// <returns></returns>
   [Fact]
   public async Task PreservesBytesInMemory()
   {
-    var fitFile = await new Reader().ReadAsync(source_);
+    var fitFiles = await new Reader().ReadAsync(source_);
     var ms = new MemoryStream();
-    new Writer().Write(fitFile, ms);
+    new Writer().Write(fitFiles, ms);
 
-    FitAssert.AreEquivalentExceptHeader(ms, fitFile.GetBytes());
+    FitAssert.AreEquivalentExceptHeader(ms, fitFiles.FirstOrDefault().GetBytes());
   }
 
   [Fact]

--- a/Ui/FitEdit.Ui.Desktop/create-release-win.ps1
+++ b/Ui/FitEdit.Ui.Desktop/create-release-win.ps1
@@ -9,11 +9,11 @@ $rid = "win-x64"
 $authors = "EnduraByte LLC"
 $packId = "FitEdit"
 $certTmpPath = "cert.tmp.crt"
-$certKey = $env:FITEDIT_WINDOWS_CODE_SIGN_KEY
+$certKey = $env:ENDURABYTE_WINDOWS_CODE_SIGN_KEY
 
 pushd $PSScriptRoot
 
-& ./Decode-FromBase64.ps1 $env:FITEDIT_WINDOWS_CODE_SIGN_CERTIFICATE $certTmpPath
+& ./Decode-FromBase64.ps1 $env:ENDURABYTE_WINDOWS_CODE_SIGN_CERTIFICATE $certTmpPath
 $certTmpPath = "$PSScriptRoot/$certTmpPath"
 echo "Created $certTmpPath..."
 

--- a/Ui/FitEdit.Ui.iOS/Info.plist
+++ b/Ui/FitEdit.Ui.iOS/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleIdentifier</key>
     <string>com.endurabyte.fitedit</string>
     <key>CFBundleShortVersionString</key>
-    <string>4.9.0</string>
+    <string>5.0.0</string>
     <key>LSRequiresIPhoneOS</key>
     <true />
     <key>MinimumOSVersion</key>
@@ -57,6 +57,6 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>38</string>
+    <string>39</string>
   </dict>
 </plist>


### PR DESCRIPTION
FitEdit can now read and write multiple FIT files in one physical file.

Other fixes:

- Do not write message definition fields with zero size: Garmin Connect rejects such FIT files.
- String fields: Do not writ null terminators
- Unless told otherwise, assume field mum 253 is timestamp.