### PR TITLE
Backfill repair: Handle no activity mesg

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
     <Nullable>disable</Nullable>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>5.7.5</VersionPrefix>
-    <BuildIncrement>47</BuildIncrement>
+    <VersionPrefix>5.7.6</VersionPrefix>
+    <BuildIncrement>48</BuildIncrement>
     <VersionSuffix></VersionSuffix>
     <Product>FitEdit</Product>
     <Copyright>EnduraByte LLC 2024</Copyright>

--- a/Infrastructure/FitEdit.Data/Fit/FitFileExtensions.cs
+++ b/Infrastructure/FitEdit.Data/Fit/FitFileExtensions.cs
@@ -883,6 +883,9 @@ public static class FitFileExtensions
   /// </summary>
   private static void ReconstructSessions(FitFile? source, FitFile dest)
   {
+    if (source is null)
+      return;
+    
     var sessions = source.Get<SessionMesg>();
     var sports = source.Get<SportMesg>();
 
@@ -906,7 +909,9 @@ public static class FitFileExtensions
     }
 
     // Reconstruct sessions from sports and laps
-    var activity = source.Get<ActivityMesg>().First();
+    var activity = source.Get<ActivityMesg>().FirstOrDefault() 
+       ?? ReconstructActivity(source);
+    
     activity.SetNumSessions((ushort)sports.Count);
 
     var laps = source.Get<LapMesg>();


### PR DESCRIPTION
Creates a basic ActivityMesg if there is none, when using the backfill repair
