### PR TITLE
Fix map edit

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,8 +9,8 @@
     <Nullable>disable</Nullable>
     <LangVersion>latest</LangVersion>
 
-    <VersionPrefix>5.8.0</VersionPrefix>
-    <BuildIncrement>46</BuildIncrement>
+    <VersionPrefix>5.8.1</VersionPrefix>
+    <BuildIncrement>47</BuildIncrement>
     <VersionSuffix></VersionSuffix>
     <Product>FitEdit</Product>
     <Copyright>EnduraByte LLC 2024</Copyright>

--- a/Ui/FitEdit.Ui.iOS/Info.plist
+++ b/Ui/FitEdit.Ui.iOS/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleIdentifier</key>
     <string>com.endurabyte.fitedit</string>
     <key>CFBundleShortVersionString</key>
-    <string>5.8.0</string>
+    <string>5.8.1</string>
     <key>LSRequiresIPhoneOS</key>
     <true />
     <key>MinimumOSVersion</key>
@@ -57,6 +57,6 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>46</string>
+    <string>47</string>
   </dict>
 </plist>


### PR DESCRIPTION
## What does this pull request do?

Fixes map edit. When at least one GPS coord is at 0,0 lat,lon, the number of Cooordinates does not match the number of Records. Now the count always matches.

## How is it tested?

Manually by loading a FIT file with at least one 0,0 coordinate

